### PR TITLE
User: add locale & allow them to control their settings

### DIFF
--- a/fixtures/user.yaml
+++ b/fixtures/user.yaml
@@ -1,6 +1,7 @@
 App\Entity\User:
     base_user (template):
         password: <encodePassword(@self, 'test')>
+        locale: en
 
     user (extends base_user):
         email: 'user@test.com'

--- a/migrations/Version20210824073653.php
+++ b/migrations/Version20210824073653.php
@@ -34,4 +34,9 @@ final class Version20210824073653 extends AbstractMigration
         $this->addSql('ALTER TABLE `database` DROP FOREIGN KEY FK_C953062E7E3C61F9');
         $this->addSql('ALTER TABLE `database` ADD CONSTRAINT FK_C953062E7E3C61F9 FOREIGN KEY (owner_id) REFERENCES user (id)');
     }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
 }

--- a/migrations/Version20210825120223.php
+++ b/migrations/Version20210825120223.php
@@ -25,4 +25,9 @@ final class Version20210825120223 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE `database` DROP status');
     }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
 }

--- a/migrations/Version20210831142926.php
+++ b/migrations/Version20210831142926.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+final class Version20210831142926 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'Add locale on User.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD locale VARCHAR(2) NOT NULL');
+        $this->addSql('UPDATE user SET locale = :locale;', ['locale' => $this->container->getParameter('kernel.default_locale')]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP locale');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/src/Command/MakeUserCommand.php
+++ b/src/Command/MakeUserCommand.php
@@ -27,6 +27,7 @@ final class MakeUserCommand extends Command
         private UserPasswordHasherInterface $hasher,
         private EntityManagerInterface $manager,
         private ValidatorInterface $validator,
+        private array $enabledLocales,
     ) {
         parent::__construct();
     }
@@ -55,11 +56,13 @@ final class MakeUserCommand extends Command
 
             return $password;
         });
+        $locale = $io->choice('Locale', $this->enabledLocales);
         $role = $io->choice('Role', User::getAvailableRoles(), 'ROLE_USER');
 
         $user = new User();
         $user->setEmail($email)
             ->setPassword($this->hasher->hashPassword($user, $plainPassword))
+            ->setLocale($locale)
             ->setRole($role);
 
         try {

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -44,6 +44,9 @@ final class DashboardController extends AbstractDashboardController
             throw new BadRequestHttpException();
         }
 
+        $this->getUser()->setLocale($locale);
+        $this->getDoctrine()->getManager()->flush();
+
         $request->getSession()->set('_locale', $locale);
         $redirectUrl = $request->headers->get('referer');
         if (empty($redirectUrl) || str_contains($redirectUrl, '/switch-locale')) {

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -7,15 +7,17 @@ namespace App\Controller\Admin;
 use App\Entity\Backup;
 use App\Entity\Database;
 use App\Entity\User;
+use App\Helper\LocaleHelper;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\RouteMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Intl\Languages;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 final class DashboardController extends AbstractDashboardController
 {
@@ -60,8 +62,16 @@ final class DashboardController extends AbstractDashboardController
             ->setPermission(User::ROLE_ADMIN);
 
         $localeLinks = array_map(static function (string $locale): RouteMenuItem {
-            return MenuItem::linkToRoute(ucfirst(Languages::getName($locale, $locale)), null, 'admin_switch_locale', ['locale' => $locale]);
+            return MenuItem::linkToRoute(LocaleHelper::getLanguageName($locale), null, 'admin_switch_locale', ['locale' => $locale]);
         }, $this->enabledLocales);
         yield MenuItem::subMenu('menu.switch_locale', 'fas fa-language')->setSubItems($localeLinks);
+    }
+
+    public function configureUserMenu(UserInterface $user): UserMenu
+    {
+        return parent::configureUserMenu($user)
+            ->addMenuItems([
+                MenuItem::linkToRoute('menu.settings', 'fas fa-user-cog', 'app_user_settings'),
+            ]);
     }
 }

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Admin;
 
 use App\Admin\Field\BadgeField;
 use App\Entity\User;
+use App\Helper\LocaleHelper;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -16,6 +17,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class UserCrudController extends AbstractCrudController
 {
+    public function __construct(private array $enabledLocales)
+    {
+    }
+
     public static function getEntityFqcn(): string
     {
         return User::class;
@@ -65,6 +70,8 @@ class UserCrudController extends AbstractCrudController
             ->setRequired(Crud::PAGE_NEW === $pageName);
         yield ChoiceField::new('role', 'user.field.role')
             ->setChoices(array_combine(array_map(fn (string $role): string => 'user.choices.role.' . $role, User::getAvailableRoles()), User::getAvailableRoles()));
+        yield ChoiceField::new('locale', 'user.field.locale')
+            ->setChoices(array_combine(array_map(fn (string $locale): string => LocaleHelper::getLanguageName($locale), $this->enabledLocales), $this->enabledLocales));
         yield BadgeField::new('databases', 'user.field.databases')
             ->formatValue(function ($value) {
                 return \count($value);

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -58,6 +58,9 @@ class SecurityController extends AbstractController
         ]);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     #[Route(path: '/logout', name: 'app_logout')]
     public function logout()
     {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Form\Model\SettingsModel;
+use App\Form\Type\SettingsType;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatableMessage;
+
+final class UserController extends AbstractController
+{
+    public function __construct(
+        private AdminUrlGenerator $adminUrlGenerator,
+        private UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    #[Route('/settings', name: 'app_user_settings')]
+    public function settings(Request $request): Response
+    {
+        $user = $this->getUser();
+        $settings = SettingsModel::createFromUser($user);
+        $form = $this->createForm(SettingsType::class, $settings);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $user->setLocale($settings->locale);
+            $request->getSession()->set('_locale', $settings->locale);
+            if (null !== $settings->newPassword) {
+                $user->setPassword($this->passwordHasher->hashPassword($user, $settings->newPassword));
+            }
+
+            $this->getDoctrine()->getManager()->flush();
+            $this->addFlash('success', new TranslatableMessage('user.settings.flash_success'));
+
+            return $this->redirect($this->adminUrlGenerator->setRoute('app_user_settings')->generateUrl());
+        }
+
+        return $this->renderForm('user/settings.html.twig', [
+            'form' => $form,
+        ]);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -47,6 +47,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     #[ORM\OneToMany(mappedBy: 'owner', targetEntity: Database::class, orphanRemoval: true)]
     private Collection $databases;
 
+    #[ORM\Column(type: 'string', length: 2)]
+    #[Assert\NotBlank]
+    #[Assert\Locale]
+    private ?string $locale = null;
+
     public function __construct()
     {
         $this->databases = new ArrayCollection();
@@ -179,5 +184,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     public function setPlainPassword(?string $plainPassword): void
     {
         $this->plainPassword = $plainPassword;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(?string $locale): self
+    {
+        $this->locale = $locale;
+
+        return $this;
     }
 }

--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use App\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 
 class LocaleSubscriber implements EventSubscriberInterface
 {
@@ -24,11 +26,18 @@ class LocaleSubscriber implements EventSubscriberInterface
         $request->setLocale($request->getSession()->get('_locale', $this->defaultLocale));
     }
 
+    public function onLoginSuccess(LoginSuccessEvent $event): void
+    {
+        \assert($event->getUser() instanceof User);
+        $event->getRequest()->getSession()->set('_locale', $event->getUser()->getLocale());
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
             // must be registered before (i.e. with a higher priority than) the default Locale listener
             KernelEvents::REQUEST => [['onKernelRequest', 20]],
+            LoginSuccessEvent::class => [['onLoginSuccess', 21]],
         ];
     }
 }

--- a/src/Form/Model/SettingsModel.php
+++ b/src/Form/Model/SettingsModel.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Model;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Validator\Constraints as SecurityAssert;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+final class SettingsModel
+{
+    #[Assert\NotBlank]
+    #[Assert\Locale]
+    public ?string $locale = null;
+
+    public ?string $currentPassword = null;
+
+    public ?string $newPassword = null;
+
+    #[Assert\Callback]
+    public function validatePassword(ExecutionContextInterface $context): void
+    {
+        if (null !== $this->newPassword) {
+            $context->getValidator()
+                ->inContext($context)
+                ->atPath('currentPassword')
+                ->validate($this->currentPassword, new Assert\NotBlank());
+        }
+
+        if (null !== $this->currentPassword) {
+            $context->getValidator()
+                ->inContext($context)
+                ->atPath('currentPassword')
+                ->validate($this->currentPassword, new SecurityAssert\UserPassword());
+        }
+    }
+
+    public static function createFromUser(User $user): self
+    {
+        $model = new self();
+        $model->locale = $user->getLocale();
+
+        return $model;
+    }
+}

--- a/src/Form/Type/SettingsType.php
+++ b/src/Form/Type/SettingsType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Type;
+
+use App\Form\Model\SettingsModel;
+use App\Helper\LocaleHelper;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SettingsType extends AbstractType
+{
+    public function __construct(private array $enabledLocales)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('locale', ChoiceType::class, [
+                'label' => 'user.settings.locale',
+                'choices' => $this->enabledLocales,
+                'choice_label' => static function (string $locale): string {
+                    return LocaleHelper::getLanguageName($locale);
+                },
+                'choice_translation_domain' => false,
+            ])
+            ->add('currentPassword', PasswordType::class, [
+                'label' => 'user.settings.current_password',
+                'required' => false,
+            ])
+            ->add('newPassword', PasswordType::class, [
+                'label' => 'user.settings.new_password',
+                'required' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('data_class', SettingsModel::class);
+    }
+}

--- a/src/Helper/LocaleHelper.php
+++ b/src/Helper/LocaleHelper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helper;
+
+use Symfony\Component\Intl\Languages;
+
+final class LocaleHelper
+{
+    public static function getLanguageName(string $locale): string
+    {
+        return ucfirst(Languages::getName($locale, $locale));
+    }
+}

--- a/templates/user/settings.html.twig
+++ b/templates/user/settings.html.twig
@@ -1,0 +1,23 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% block page_title 'user.settings.title'|trans %}
+{% form_theme form '@EasyAdmin/crud/form_theme.html.twig' %}
+{% block page_content %}
+    {{ form_start(form) }}
+        <div class="row">
+            {{ form_row(form.locale, { 'row_attr': { 'class': 'col-12 col-md-3' } }) }}
+        </div>
+
+        <div class="row">
+            {{ form_row(form.currentPassword, { 'row_attr': { 'class': 'col-12 col-md-3' } }) }}
+            {{ form_row(form.newPassword, { 'row_attr': { 'class': 'col-12 col-md-3' } }) }}
+        </div>
+
+        <p>
+            <button type="submit" class="btn btn-primary" name="_submit">
+                <i class="fas fa-fw fa-check"></i>
+                {{ 'user.settings.submit'|trans }}
+            </button>
+        </p>
+    {{ form_end(form) }}
+{% endblock %}

--- a/tests/Command/MakeUserCommandTest.php
+++ b/tests/Command/MakeUserCommandTest.php
@@ -18,7 +18,7 @@ final class MakeUserCommandTest extends KernelTestCase
 
         $command = $application->find('app:make-user');
         $commandTester = new CommandTester($command);
-        $commandTester->setInputs(['contact@test.com', 'test', 'ROLE_ADMIN']);
+        $commandTester->setInputs(['contact@test.com', 'test', 'en', 'ROLE_ADMIN']);
 
         $commandTester->execute(['command' => $command->getName()]);
         $output = $commandTester->getDisplay();
@@ -47,8 +47,9 @@ final class MakeUserCommandTest extends KernelTestCase
 
     public function provideInvalidCases(): iterable
     {
-        yield 'no_email' => ['', '', ''];
-        yield 'invalid_email' => ['contact', '', ''];
-        yield 'no_password' => ['contact@test.com', '', ''];
+        yield 'no_email' => ['', '', '', ''];
+        yield 'invalid_email' => ['contact', '', '', ''];
+        yield 'no_password' => ['contact@test.com', '', '', ''];
+        yield 'no_locale' => ['contact@test.com', 'test', '', ''];
     }
 }

--- a/tests/Controller/AbstractControllerTest.php
+++ b/tests/Controller/AbstractControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Controller;
 
 use App\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -14,10 +15,13 @@ abstract class AbstractControllerTest extends WebTestCase
     public const USER_ROLE_ADMIN = 2;
 
     protected static KernelBrowser $client;
+    protected AdminUrlGenerator $adminUrlGenerator;
 
     protected function setUp(): void
     {
         static::$client = static::createClient();
+        self::bootKernel();
+        $this->adminUrlGenerator = self::getContainer()->get(AdminUrlGenerator::class);
     }
 
     protected function loginAsUser(): void

--- a/tests/Controller/Admin/AbstractCrudControllerTest.php
+++ b/tests/Controller/Admin/AbstractCrudControllerTest.php
@@ -5,22 +5,12 @@ declare(strict_types=1);
 namespace App\Tests\Controller\Admin;
 
 use App\Tests\Controller\AbstractControllerTest;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 
 abstract class AbstractCrudControllerTest extends AbstractControllerTest
 {
-    protected AdminUrlGenerator $adminUrlGenerator;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        self::bootKernel();
-        $this->adminUrlGenerator = self::getContainer()->get(AdminUrlGenerator::class);
-    }
-
     public function testIndex(): void
     {
-        $url = $this->getActionUrl('index');
+        $url = $this->getCrudActionUrl('index');
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -32,7 +22,7 @@ abstract class AbstractCrudControllerTest extends AbstractControllerTest
 
     public function testNew(): void
     {
-        $url = $this->getActionUrl('new');
+        $url = $this->getCrudActionUrl('new');
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -44,7 +34,7 @@ abstract class AbstractCrudControllerTest extends AbstractControllerTest
 
     abstract protected function getControllerClass(): string;
 
-    protected function getActionUrl(string $action, ?int $entityId = null): string
+    protected function getCrudActionUrl(string $action, ?int $entityId = null): string
     {
         $generator = $this->adminUrlGenerator->setController($this->getControllerClass())
             ->setAction($action);

--- a/tests/Controller/Admin/BackupCrudControllerTest.php
+++ b/tests/Controller/Admin/BackupCrudControllerTest.php
@@ -10,7 +10,7 @@ final class BackupCrudControllerTest extends AbstractCrudControllerTest
 {
     public function testNew(): void
     {
-        $url = $this->getActionUrl('new');
+        $url = $this->getCrudActionUrl('new');
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -22,7 +22,7 @@ final class BackupCrudControllerTest extends AbstractCrudControllerTest
 
     public function testEdit(): void
     {
-        $url = $this->getActionUrl('edit', 1);
+        $url = $this->getCrudActionUrl('edit', 1);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');

--- a/tests/Controller/Admin/DatabaseCrudControllerTest.php
+++ b/tests/Controller/Admin/DatabaseCrudControllerTest.php
@@ -10,7 +10,7 @@ final class DatabaseCrudControllerTest extends AbstractCrudControllerTest
 {
     public function testEdit(): void
     {
-        $url = $this->getActionUrl('edit', 1);
+        $url = $this->getCrudActionUrl('edit', 1);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -26,7 +26,7 @@ final class DatabaseCrudControllerTest extends AbstractCrudControllerTest
 
     public function testShowDatabaseBackupsAction(): void
     {
-        $url = $this->getActionUrl('showDatabaseBackupsAction', 1);
+        $url = $this->getCrudActionUrl('showDatabaseBackupsAction', 1);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -42,7 +42,7 @@ final class DatabaseCrudControllerTest extends AbstractCrudControllerTest
 
     public function testCheckConnection(): void
     {
-        $url = $this->getActionUrl('checkConnection', 1);
+        $url = $this->getCrudActionUrl('checkConnection', 1);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -61,7 +61,7 @@ final class DatabaseCrudControllerTest extends AbstractCrudControllerTest
 
     public function testLaunchBackupAction(): void
     {
-        $url = $this->getActionUrl('launchBackupAction', 1);
+        $url = $this->getCrudActionUrl('launchBackupAction', 1);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -80,7 +80,7 @@ final class DatabaseCrudControllerTest extends AbstractCrudControllerTest
 
     public function testDelete(): void
     {
-        $url = $this->getActionUrl('delete', 1);
+        $url = $this->getCrudActionUrl('delete', 1);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');

--- a/tests/Controller/Admin/UserCrudControllerTest.php
+++ b/tests/Controller/Admin/UserCrudControllerTest.php
@@ -45,7 +45,7 @@ class UserCrudControllerTest extends AbstractCrudControllerTest
 
     public function testNewWithSimpleUser(): void
     {
-        $url = $this->getActionUrl(Action::NEW);
+        $url = $this->getCrudActionUrl(Action::NEW);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -61,7 +61,7 @@ class UserCrudControllerTest extends AbstractCrudControllerTest
 
     public function testNewWithAdmin(): void
     {
-        $url = $this->getActionUrl(Action::NEW);
+        $url = $this->getCrudActionUrl(Action::NEW);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -74,7 +74,7 @@ class UserCrudControllerTest extends AbstractCrudControllerTest
 
     public function testEditWithSimpleUser(): void
     {
-        $url = $this->getActionUrl(Action::EDIT, self::USER_ROLE_USER);
+        $url = $this->getCrudActionUrl(Action::EDIT, self::USER_ROLE_USER);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -90,7 +90,7 @@ class UserCrudControllerTest extends AbstractCrudControllerTest
 
     public function testEditWithAdminUser(): void
     {
-        $url = $this->getActionUrl(Action::EDIT, self::USER_ROLE_USER);
+        $url = $this->getCrudActionUrl(Action::EDIT, self::USER_ROLE_USER);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -103,7 +103,7 @@ class UserCrudControllerTest extends AbstractCrudControllerTest
 
     public function testDeleteWithAdminUser(): void
     {
-        $url = $this->getActionUrl(Action::DELETE, self::USER_ROLE_USER);
+        $url = $this->getCrudActionUrl(Action::DELETE, self::USER_ROLE_USER);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');
@@ -115,7 +115,7 @@ class UserCrudControllerTest extends AbstractCrudControllerTest
 
     public function testDeleteWithSimpleUser(): void
     {
-        $url = $this->getActionUrl(Action::DELETE, self::USER_ROLE_ADMIN);
+        $url = $this->getCrudActionUrl(Action::DELETE, self::USER_ROLE_ADMIN);
 
         self::$client->request('GET', $url);
         self::assertResponseRedirects('/login');

--- a/tests/Controller/UserControllerTest.php
+++ b/tests/Controller/UserControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+final class UserControllerTest extends AbstractControllerTest
+{
+    public function testSettings(): void
+    {
+        $url = $this->adminUrlGenerator->setRoute('app_user_settings')->generateUrl();
+
+        self::$client->request('GET', $url);
+        self::assertResponseRedirects('/login');
+
+        $this->loginAsUser();
+        self::$client->request('GET', $url);
+        self::assertResponseIsSuccessful();
+
+        self::$client->submitForm('_submit', ['settings' => [
+            'locale' => 'en',
+            'currentPassword' => 'test',
+            'newPassword' => 'test',
+        ]]);
+        self::assertResponseRedirects();
+        $crawler = self::$client->followRedirect();
+        self::assertCount(1, $crawler->filter('.alert-success'));
+    }
+}

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -90,4 +90,12 @@ final class UserTest extends TestCase
         self::assertCount(0, $entity->getDatabases());
         self::assertNull($database->getOwner());
     }
+
+    public function testLocale(): void
+    {
+        $entity = new User();
+        self::assertNull($entity->getLocale());
+        $entity->setLocale('fr');
+        self::assertSame('fr', $entity->getLocale());
+    }
 }

--- a/tests/Helper/LocaleHelperTest.php
+++ b/tests/Helper/LocaleHelperTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Helper;
+
+use App\Helper\LocaleHelper;
+use PHPUnit\Framework\TestCase;
+
+final class LocaleHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testGetLanguageName(string $locale, string $expectedLanguageName): void
+    {
+        self::assertSame($expectedLanguageName, LocaleHelper::getLanguageName($locale));
+    }
+
+    public function provideCases(): iterable
+    {
+        yield 'english' => ['en', 'English'];
+        yield 'french' => ['fr', 'Français'];
+        yield 'german' => ['de', 'Deutsch'];
+    }
+}

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -85,6 +85,7 @@ menu:
     backups: Backups
     users: Users
     switch_locale: Locale
+    settings: Settings
 
 security:
     login:
@@ -111,7 +112,15 @@ user:
         password: Password
         role: Role
         databases: Databases
+        locale: Language
     choices:
         role:
             ROLE_USER: User
             ROLE_ADMIN: Admin
+    settings:
+        title: Settings
+        locale: Language
+        current_password: Current password
+        new_password: New password
+        submit: Save settings
+        flash_success: New settings have been successfully saved.

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -85,6 +85,7 @@ menu:
     backups: Sauvegardes
     users: Utilisateurs
     switch_locale: Langue
+    settings: Paramètres
 
 security:
     login:
@@ -111,8 +112,15 @@ user:
         password: Mot de passe
         role: Rôle
         databases: Bases de données
+        locale: Langue
     choices:
         role:
             ROLE_USER: Utilisateur
             ROLE_ADMIN: Administrateur
-
+    settings:
+        title: Paramètres
+        locale: Langue
+        current_password: Mot de passe actuel
+        new_password: Nouveau mot de passe
+        submit: Enregistrer les paramètres
+        flash_success: Les nouveaux paramètres ont été enregistrés.


### PR DESCRIPTION
This PR:

- adds a "locale" property on users
- during the migration, sets their locale on the default settings
- after login, the locale is changed to the user's set locale
- adds a Settings page, allowing the user to change their locale & their password