### PR TITLE
Docker compose: add MariaDB & minio images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,3 +4,41 @@ services:
     mailer:
         image: schickling/mailcatcher
         ports: [1025, 1080]
+
+    mariadb:
+        image: mariadb:10.6
+        ports:
+            - '3307:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: test_db
+        volumes:
+            - ./src/Faker/Provider/fixture.sql:/docker-entrypoint-initdb.d/fixture.sql
+            - db_data:/var/lib/mysql
+
+    minio:
+        image: minio/minio
+        environment:
+            MINIO_ROOT_USER: minio
+            MINIO_ROOT_PASSWORD: minio123
+        volumes:
+            - ./data/minio:/data
+        command: server /data --address ":9004" --console-address ":9001"
+        ports:
+            - 9004:9004
+            - 9001:9001
+
+    createbuckets:
+        image: minio/mc
+        depends_on:
+            - minio
+        entrypoint: >
+            /bin/sh -c "
+            /usr/bin/mc alias set myminio http://minio:9004 minio minio123;
+            /usr/bin/mc mb myminio/somebucketname;
+            /usr/bin/mc policy set public myminio/somebucketname;
+            exit 0;
+            "
+
+volumes:
+    db_data:


### PR DESCRIPTION
This is required for dev as we currently can't even load fixtures in dev env :/ 